### PR TITLE
fix over midnight date and time correction on the last day of the month

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -34,12 +34,8 @@ get '/ics' do
     hour = time.split(':')[0].to_i
     minute = time.split(':')[1].to_i
 
-    if hour >= 24
-      hour -= 24
-      date += 1
-    end
-
-    start_in_this_year = DateTime.civil(Time.now.year, month, date, hour, minute)
+    start_in_this_year = DateTime.civil(Time.now.year, month, date, (hour % 24), minute)
+    start_in_this_year = start_in_this_year.next_day if hour >= 24
     anime.start = [start_in_this_year, start_in_this_year.next_year].min_by {|d| (d - DateTime.now).abs}
     anime
   end


### PR DESCRIPTION
![naosuno](https://cloud.githubusercontent.com/assets/11156/6092553/3d8f6d86-af27-11e4-8bb1-8471b4bdb708.jpg)
could you fix this?

example input:
```
「冴えない彼女の育てかた」#0～#3振り返り上映会
放送終了  01/31 25:00 - 26:37
```

before: 1/31 25:00 -> 1/32 01:00 (`ArgumentError - invalid date` on DateTime.civil)
after: 1/31 25:00 -> 2/1 01:00